### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ And then execute:
 
 Or install it yourself as:
 
-    $ gem install ostruct
+    $ gem install rubysl-ostruct
 
 ## Usage
 


### PR DESCRIPTION
I was unable to install the gem using the initial statement `gem install ostruct`. And in Ruby gems - I found a different instruction that worked.

`gem install rubysl-ostruct`

And that's what I have proposed to update in the README