### PR TITLE
Avoid self calling our public methods.

### DIFF
--- a/lib/ostruct.rb
+++ b/lib/ostruct.rb
@@ -124,7 +124,7 @@ class OpenStruct
     @table = {}
     if hash
       hash.each_pair do |k, v|
-        self[k] = v
+        set_ostruct_member_value!(k, v)
       end
     end
   end
@@ -228,7 +228,7 @@ class OpenStruct
       if len != 1
         raise ArgumentError, "wrong number of arguments (given #{len}, expected 1)", caller(1)
       end
-      self[mname]= args[0]
+      set_ostruct_member_value!(mname, args[0])
     elsif len == 0
     elsif @table.key?(mid)
       raise ArgumentError, "wrong number of arguments (given #{len}, expected 0)"
@@ -272,6 +272,8 @@ class OpenStruct
     new_ostruct_member!(name)
     @table[name] = value
   end
+  alias_method :set_ostruct_member_value!, :[]=
+  private :set_ostruct_member_value!
 
   # :call-seq:
   #   ostruct.dig(name, *identifiers) -> object

--- a/lib/ostruct.rb
+++ b/lib/ostruct.rb
@@ -222,7 +222,7 @@ class OpenStruct
     super
   end
 
-  def method_missing(mid, *args) # :nodoc:
+  private def method_missing(mid, *args) # :nodoc:
     len = args.length
     if mname = mid[/.*(?==\z)/m]
       if len != 1

--- a/test/ostruct/test_ostruct.rb
+++ b/test/ostruct/test_ostruct.rb
@@ -246,4 +246,22 @@ class TC_OpenStruct < Test::Unit::TestCase
     os = OpenStruct.new(method: :foo)
     assert_equal(os.object_id, os.method!(:object_id).call)
   end
+
+  def test_mistaken_subclass
+    sub = Class.new(OpenStruct) do
+      def [](k)
+        __send__(k)
+        super
+      end
+
+      def []=(k, v)
+        @item_set = true
+        __send__("#{k}=", v)
+        super
+      end
+    end
+    o = sub.new
+    o.foo = 42
+    assert_equal 42, o.foo
+  end
 end


### PR DESCRIPTION
Found because `json` has a bad example in its test suite.
This implementation still offers better encapsulation.
