### PR TITLE
Fix warning: constant Gem::ConfigMap is deprecated

### DIFF
--- a/test/lib/envutil.rb
+++ b/test/lib/envutil.rb
@@ -278,6 +278,5 @@ if defined?(RbConfig)
     CONFIG['bindir'] = dir
     CONFIG['ruby_install_name'] = name
     CONFIG['RUBY_INSTALL_NAME'] = name
-    Gem::ConfigMap[:bindir] = dir if defined?(Gem::ConfigMap)
   end
 end


### PR DESCRIPTION
Gem::ConfigMap is deprecated. So, I simple delete this.

cf. https://github.com/rubygems/rubygems/pull/2857