### PR TITLE
Allow properties to be accessed even when the object is moved to another Ractor

### DIFF
--- a/lib/ostruct.rb
+++ b/lib/ostruct.rb
@@ -223,9 +223,9 @@ class OpenStruct
     unless @table.key?(name) || is_method_protected!(name)
       getter_proc = Proc.new { @table[name] }
       setter_proc = Proc.new {|x| @table[name] = x}
-      if defined?(Ractor)
-        Ractor.make_shareable(getter_proc)
-        Ractor.make_shareable(setter_proc)
+      if defined?(::Ractor)
+        ::Ractor.make_shareable(getter_proc)
+        ::Ractor.make_shareable(setter_proc)
       end
       define_singleton_method!(name, &getter_proc) 
       define_singleton_method!("#{name}=", &setter_proc)

--- a/lib/ostruct.rb
+++ b/lib/ostruct.rb
@@ -221,8 +221,14 @@ class OpenStruct
   #
   def new_ostruct_member!(name) # :nodoc:
     unless @table.key?(name) || is_method_protected!(name)
-      define_singleton_method!(name) { @table[name] }
-      define_singleton_method!("#{name}=") {|x| @table[name] = x}
+      getter_proc = Proc.new { @table[name] }
+      setter_proc = Proc.new {|x| @table[name] = x}
+      if defined?(Ractor)
+        Ractor.make_shareable(getter_proc)
+        Ractor.make_shareable(setter_proc)
+      end
+      define_singleton_method!(name, &getter_proc) 
+      define_singleton_method!("#{name}=", &setter_proc)
     end
   end
   private :new_ostruct_member!

--- a/test/ostruct/test_ostruct.rb
+++ b/test/ostruct/test_ostruct.rb
@@ -368,6 +368,18 @@ class TC_OpenStruct < Test::Unit::TestCase
     RUBY
   end if defined?(Ractor)
 
+  def test_access_methods_from_different_ractor
+    assert_ractor(<<~RUBY, require: 'ostruct')
+      os = OpenStruct.new
+      os.value = 100
+      r = Ractor.new(os) do |x|
+        v = x.value
+        Ractor.yield v
+      end
+      assert 100 == r.take
+    RUBY
+  end if defined?(Ractor)
+
   def test_legacy_yaml
     s = "--- !ruby/object:OpenStruct\ntable:\n  :foo: 42\n"
     o = YAML.safe_load(s, permitted_classes: [Symbol, OpenStruct])


### PR DESCRIPTION
By having the methods defined using shareable Procs, objects that are moved into another Ractor can still use these methods.