### PR TITLE
Alias less methods

### DIFF
--- a/lib/ostruct.rb
+++ b/lib/ostruct.rb
@@ -453,7 +453,12 @@ class OpenStruct
   end
 
   # Make all public methods (builtin or our own) accessible with <code>!</code>:
-  instance_methods.each do |method|
+  give_access = instance_methods
+  # See https://github.com/ruby/ostruct/issues/30
+  give_access -= %i[instance_exec instance_eval eval] if RUBY_ENGINE == 'jruby'
+  give_access.each do |method|
+    next if method.match(/\W$/)
+
     new_name = "#{method}!"
     alias_method new_name, method
   end

--- a/test/ostruct/test_ostruct.rb
+++ b/test/ostruct/test_ostruct.rb
@@ -280,6 +280,7 @@ class TC_OpenStruct < Test::Unit::TestCase
     os = OpenStruct.new(method: :foo, hash: 42)
     assert_equal(os.object_id, os.method!(:object_id).call)
     assert_not_equal(42, os.hash!)
+    refute os.methods.include?(:"!~!")
   end
 
   def test_override_subclass


### PR DESCRIPTION
Skips methods that do not end with letter (in particular `!~` and `=~`)
For JRuby, also skip `instance_exec`, `instance_eval` and `eval`