### PR TITLE
Avoid using block_given in the presence of aliases

### DIFF
--- a/lib/ostruct.rb
+++ b/lib/ostruct.rb
@@ -197,7 +197,7 @@ class OpenStruct
   #   data.each_pair.to_a   # => [[:country, "Australia"], [:capital, "Canberra"]]
   #
   def each_pair
-    return to_enum(__method__) { @table.size } unless block_given!
+    return to_enum(__method__) { @table.size } unless defined?(yield)
     @table.each_pair{|p| yield p}
     self
   end


### PR DESCRIPTION
In #41 ostruct.rb was modified to not define `block_given!` on JRuby because it would not be recognized as being the same as `block_given?` and would not work properly (and we would also warn about this situation).

Unfortunately, `each_pair` still expects `block_given!` to be defined:

https://github.com/ruby/ostruct/blob/master/lib/ostruct.rb#L200

This leads to two failures running on JRuby:

```
Failure: test_each_pair(TC_OpenStruct):
  <#<OpenStruct name="John Smith", age=70, pension=300>>
  with id <4020> was expected to be equal? to
  <#<Enumerator: #<OpenStruct name="John Smith", age=70, pension=300>:each_pair>>
  with id <4024>.
/Users/headius/projects/ostruct/test/ostruct/test_ostruct.rb:167:in `test_each_pair'
     164:   def test_each_pair
     165:     h = {name: "John Smith", age: 70, pension: 300}
     166:     os = OpenStruct.new(h)
  => 167:     assert_same os, os.each_pair{ }
     168:     assert_equal '#<Enumerator: #<OpenStruct name="John Smith", age=70, pension=300>:each_pair>', os.each_pair.inspect
     169:     assert_equal [[:name, "John Smith"], [:age, 70], [:pension, 300]], os.each_pair.to_a
     170:     assert_equal 3, os.each_pair.size

Failure: test_initialize(TC_OpenStruct)
/Users/headius/projects/ostruct/test/ostruct/test_ostruct.rb:10:in `test_initialize'
      7:   def test_initialize
      8:     h = {name: "John Smith", age: 70, pension: 300}
      9:     assert_equal h, OpenStruct.new(h).to_h
  => 10:     assert_equal h, OpenStruct.new(OpenStruct.new(h)).to_h
     11:     assert_equal h, OpenStruct.new(Struct.new(*h.keys).new(*h.values)).to_h
     12:   end
     13: 
```

This can be fixed by either using the un-aliased `block_given?` on JRuby, or just using `defined?(yield)` which does not require `block_given?` to be available. I have done the latter here.