### PR TITLE
Add JRuby to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     name: build (${{ matrix.ruby }} / ${{ matrix.os }})
     strategy:
       matrix:
-        ruby: [ 3.1, '3.0', 2.7, 2.6, 2.5, head, truffleruby-head ]
+        ruby: [ 3.1, '3.0', 2.7, 2.6, 2.5, head, truffleruby-head, jruby-9.3 ]
         os: [ ubuntu-latest, macos-latest ]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Should be green if `jruby-9.3` picks up the repo ostruct instead of shipped stdlib ostruct.