### PR TITLE
Provide pattern matching for OpenStruct

### DIFF
--- a/lib/ostruct.rb
+++ b/lib/ostruct.rb
@@ -429,6 +429,35 @@ class OpenStruct
   end
 
   #
+  # Returns a hash of attributes for the given keys. Provides the pattern
+  # matching interface for matching against hash patterns. For example:
+  #
+  #   require "ostruct"
+  #
+  #   def greeting_for(person)
+  #     case person
+  #     in { name: "Mary" }
+  #       "Welcome back, Mary!"
+  #     in { name: }
+  #       "Welcome stranger!"
+  #     end
+  #   end
+  #
+  #   person = OpenStruct.new(name: "Mary")
+  #   greeting_for(person) # => "Welcome back, Mary!"
+  #
+  #   person = OpenStruct.new
+  #   greeting_for(person) # => "Welcome stranger!"
+  #
+  def deconstruct_keys(keys)
+    deconstructed = {}
+    keys.each do |key|
+      deconstructed[key] = send(key)
+    end
+    deconstructed
+  end
+
+  #
   # Provides marshalling support for use by the YAML library.
   #
   def encode_with(coder) # :nodoc:

--- a/test/ostruct/test_ostruct.rb
+++ b/test/ostruct/test_ostruct.rb
@@ -412,4 +412,14 @@ class TC_OpenStruct < Test::Unit::TestCase
     assert_equal('my-class', os.class)
     assert_equal(OpenStruct, os.class!)
   end
+
+  def test_pattern_matching
+    os = OpenStruct.new(class: 'my-class', method: 'post')
+    case os
+    in { class: 'my-class', method: 'post' }
+      assert true
+    else
+      assert false
+    end
+  end
 end


### PR DESCRIPTION
It would be nice to be able to pattern match against OpenStruct.
Inspired by https://github.com/rails/rails/pull/45035

For example:

```ruby
person = OpenStruct.new(name: 'John', age: 42)
case person
in { name: 'John', age: 42 }
  puts 'John is 42'
end
```
