### PR TITLE
Use a generic getter with __callee__

### DIFF
--- a/lib/ostruct.rb
+++ b/lib/ostruct.rb
@@ -221,16 +221,15 @@ class OpenStruct
   #
   def new_ostruct_member!(name) # :nodoc:
     unless @table.key?(name) || is_method_protected!(name)
+      # use generic method with __callee__ for getter
+      singleton_class.alias_method(name, :__get_callee__!)
+
       if defined?(::Ractor)
-        getter_proc = nil.instance_eval{ Proc.new { @table[name] } }
         setter_proc = nil.instance_eval{ Proc.new {|x| @table[name] = x} }
-        ::Ractor.make_shareable(getter_proc)
         ::Ractor.make_shareable(setter_proc)
       else
-        getter_proc = Proc.new { @table[name] }
         setter_proc = Proc.new {|x| @table[name] = x}
       end
-      define_singleton_method!(name, &getter_proc)
       define_singleton_method!("#{name}=", &setter_proc)
     end
   end
@@ -252,6 +251,10 @@ class OpenStruct
         end
       end
     end
+  end
+
+  def __get_callee__!
+    @table[__callee__]
   end
 
   def freeze


### PR DESCRIPTION
This modifies the getter definition to use a single method that uses `__callee__` to access the hash.

```ruby
def __get_callee__!
  @table[__callee__]
end
```

On versions of Ruby 2.0+ and JRuby 9.4.2+ __callee__ will return the aliased name, which in this case is the key for the table.

This eliminates one of the Proc-based methods per field and also performs better on CRuby:

Before:

```
Warming up --------------------------------------
                 get    44.000  i/100ms
                 set    46.000  i/100ms
Calculating -------------------------------------
                 get    504.731  (± 8.5%) i/s -      2.508k in   5.024439s
                 set    506.779  (± 1.4%) i/s -      2.576k in   5.084061s
```

After:

```
Warming up --------------------------------------
                 get    80.000  i/100ms
                 set    65.000  i/100ms
Calculating -------------------------------------
                 get    808.319  (± 0.7%) i/s -      4.080k in   5.047805s
                 set    662.678  (± 0.9%) i/s -      3.315k in   5.002857s
```

It also uses less memory; creating 100k OpenStruct in the same way as the benchmark uses 205.2MB before and 164MB after.

Note that a similar memory savings is possible by using the following setter:

```ruby
def __set_callee__!(value)
  @name[__callee__[0..-2].intern] = value
end
```

But it is quite a bit slower than the Proc version. I think it would be worth exploring other ways we can simplify the setters too.