### PR TITLE
CI: Run Ruby 2.5 on macos-13

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,7 @@ jobs:
     needs: ruby-versions
     name: build (${{ matrix.ruby }} / ${{ matrix.os }})
     strategy:
+      fail-fast: false
       matrix:
         ruby: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
         os: [ ubuntu-latest, macos-latest ]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,5 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
-        # In order to support Ruby 2.5, use a pre-2.4 Bundler.
-        bundler: '2.3.26'
     - name: Run test
       run: bundle exec rake test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,11 @@ jobs:
       matrix:
         ruby: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
         os: [ ubuntu-latest, macos-latest ]
+        # CRuby < 2.6 does not support macos-arm64, so test those on amd64 instead
+        exclude:
+        - { os: macos-latest, ruby: '2.5' }
+        include:
+        - { os: macos-13, ruby: '2.5' }
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,5 +28,7 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
+        # In order to support Ruby 2.5, use a pre-2.4 Bundler.
+        bundler: '2.3.26'
     - name: Run test
       run: bundle exec rake test


### PR DESCRIPTION
This follows the directions of the setup-ruby GitHub Action.

```
        If you are using a matrix of Ruby versions, a good solution is to run only < 2.6 on amd64, like so:
        matrix:
          ruby: ['2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3']
          os: [ ubuntu-latest, macos-latest ]
          # CRuby < 2.6 does not support macos-arm64, so test those on amd64 instead
          exclude:
          - { os: macos-latest, ruby: '2.5' }
          include:
          - { os: macos-13, ruby: '2.5' }
```

---

Details:

Failed like

```
  Ruby 2.3.2 - 2.5 only works with Bundler 2.3
```