### PR TITLE
Exclude TruffleRuby from Actions. It easily broke our CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ jobs:
   ruby-versions:
     uses: ruby/actions/.github/workflows/ruby_versions.yml@master
     with:
+      engine: cruby-jruby
       min_version: 2.5
 
   build:


### PR DESCRIPTION
https://github.com/ruby/ostruct/actions/runs/12009038364/job/33472938802?pr=67#logs