### PR TITLE
Provide a 'Changelog' link on rubygems.org/gems/ostruct

### DIFF
--- a/ostruct.gemspec
+++ b/ostruct.gemspec
@@ -21,4 +21,6 @@ Gem::Specification.new do |spec|
 
   spec.files         = [".gitignore", "Gemfile", "COPYING", "BSDL", "README.md", "Rakefile", "bin/console", "bin/setup", "lib/ostruct.rb", "ostruct.gemspec"]
   spec.require_paths = ["lib"]
+
+  spec.metadata["changelog_uri"] = spec.homepage + "/releases"
 end


### PR DESCRIPTION
By providing a 'changelog_uri' in the metadata of the gemspec a 'Changelog' link will be shown on https://rubygems.org/gems/ostruct which makes it quick and easy for someone to check on the changes introduced with a new version.

Details of this functionality can be found on https://guides.rubygems.org/specification-reference/#metadata