### PR TITLE
Add has_key? method to OpenStruct class

### DIFF
--- a/lib/ostruct.rb
+++ b/lib/ostruct.rb
@@ -380,6 +380,30 @@ class OpenStruct
     end
   end
 
+
+  # Returns +true+ if the given name is a member of this OpenStruct object, +false+ otherwise.
+  # The given +name+ is converted to a symbol before checking.
+  #
+  #   require "ostruct"
+  #   person = OpenStruct.new("name" => "John Smith", :age => 70)
+  #   person.has_key?(:name)   # => true
+  #   person.has_key?("age")   # => true
+  #   person.has_key?(:phone)  # => false
+  #
+  # This method can be used to test for the presence of a value without creating
+  # an accessor method if it doesn't exist:
+  #
+  #   person = OpenStruct.new
+  #   person.name = "John"
+  #   person.has_key?(:name)   # => true
+  #   person.has_key?(:age)    # => false
+  #   person.age               # => nil (but creates an accessor)
+  #   person.has_key?(:age)    # => false
+  #
+  def has_key?(name)
+    @table.has_key?(name.to_sym)
+  end
+
   InspectKey = :__inspect_key__ # :nodoc:
 
   #

--- a/test/ostruct/test_ostruct.rb
+++ b/test/ostruct/test_ostruct.rb
@@ -431,4 +431,51 @@ class TC_OpenStruct < Test::Unit::TestCase
       )
     end
   end
+  def setup
+  end
+
+  def test_has_key_with_symbol
+    o = OpenStruct.new(name: "John Smith", age: 70, pension: 300)
+    assert_true o.has_key?(:name)
+    assert_true o.has_key?(:age)
+    assert_true o.has_key?(:pension)
+    assert_false o.has_key?(:address)
+  end
+
+  def test_has_key_with_string
+    o = OpenStruct.new(name: "John Smith", age: 70, pension: 300)
+    assert_true o.has_key?("name")
+    assert_true o.has_key?("age")
+    assert_true o.has_key?("pension")
+    assert_false o.has_key?("address")
+  end
+
+  def test_has_key_after_deletion
+    o = OpenStruct.new(name: "John Smith", age: 70, pension: 300)
+    o.delete_field(:name)
+    assert_false o.has_key?(:name)
+  end
+
+  def test_has_key_with_nil_value
+    o = OpenStruct.new(name: "John Smith", age: 70, pension: 300)
+    o.pension = nil
+    assert_true o.has_key?(:pension)
+  end
+
+  def test_has_key_with_new_ostruct
+    os = OpenStruct.new
+    assert_false os.has_key?(:any_key)
+  end
+
+  def test_has_key_after_setting_value
+    o = OpenStruct.new(name: "John Smith", age: 70, pension: 300)
+    o.phone = "123-456-7890"
+    assert_true o.has_key?(:phone)
+  end
+
+  def test_has_key_case_sensitivity
+    o = OpenStruct.new(name: "John Smith", age: 70, pension: 300)
+    assert_true o.has_key?(:name)
+    assert_false o.has_key?(:Name)
+  end
 end


### PR DESCRIPTION
Adds has_key? method to OpenStruct class to check if a given name exists as a member, which allows checking for presence of a key without creating an accessor method; it also allows for distinguishing between a method which has never been set and one which been set to nil. 