### PR TITLE
Don't need to use admin secret for `gh release`

### DIFF
--- a/.github/workflows/push_gem.yml
+++ b/.github/workflows/push_gem.yml
@@ -43,4 +43,4 @@ jobs:
           tag_name="$(git describe --tags --abbrev=0)"
           gh release create "${tag_name}" --verify-tag --generate-notes
         env:
-          GITHUB_TOKEN: ${{ secrets.MATZBOT_GITHUB_WORKFLOW_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I misunderstood how to use `gh release` in `push_gem.yml`. That workflow will use token of tag author automatically.
