### PR TITLE
Add object_id to protected methods

### DIFF
--- a/lib/ostruct.rb
+++ b/lib/ostruct.rb
@@ -254,6 +254,8 @@ class OpenStruct
   private def is_method_protected!(name) # :nodoc:
     if !respond_to?(name, true)
       false
+    elsif name.match?(/^object_id$/)
+      true
     elsif name.match?(/!$/)
       true
     else


### PR DESCRIPTION
This PR fixes issue #75.

While working on a project with ruby 3.4.7 we were continuously seeing the following warning:

`warning: redefining 'object_id' may cause serious problems`

This PR adds `object_id` to the check for protected methods. 