### PR TITLE
Re-add TruffleRuby in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,6 @@ jobs:
   ruby-versions:
     uses: ruby/actions/.github/workflows/ruby_versions.yml@master
     with:
-      engine: cruby-jruby
       min_version: 2.5
 
   build:


### PR DESCRIPTION
Related: ruby/ostruct#68
https://github.com/ruby/ostruct/actions/runs/12009038364/job/33472938802?pr=67#logs is not accessible, so I cannot know what was the failure.
Anyway there is no failure now.
@hsbt Please mention `@eregon` on such PRs. You can still merge them immediately but it would be nice to let me know.